### PR TITLE
Fixing a problem in older enum files

### DIFF
--- a/ocsf_validator/processor.py
+++ b/ocsf_validator/processor.py
@@ -362,8 +362,14 @@ class IncludeParser(MergeParser):
                         self._collector.handle(MissingIncludeError(path, target))
                     elif update:
                         other = self._reader[t]
-                        for key in trail:
-                            other = other[key]
+                        try:
+                            for key in trail:
+                                other = other[key]
+                        except KeyError:
+                            # Older copies of the schema use files in enums/ that
+                            # don't mirror the structure of the files they're
+                            # being included into.
+                            pass
                         deep_merge(defn, other)
 
                 if remove:

--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -82,6 +82,7 @@ class OcsfCategory(TypedDict):
     caption: str
     description: str
     uid: int
+    type: NotRequired[str] # older categories.json definitions
 
 
 class OcsfCategories(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-validator"
-version = "0.1.1"
+version = "0.1.2"
 description = "OCSF Schema Validation"
 authors = ["Jeremy Fisher <jeremy@query.ai>"]
 readme = "README.md"


### PR DESCRIPTION
Older copies of the schema had files in `enums/` that didn't mirror the structure of the files they were being included into. The include parser has been modified to handle this case.