### PR TITLE
Adding attribute type validation

### DIFF
--- a/ocsf_validator/errors.py
+++ b/ocsf_validator/errors.py
@@ -219,3 +219,7 @@ class UndefinedAttributeError(ValidationError):
         super().__init__(
             f"Attribute `{attr}` in {file} is not defined in any attribute"
         )
+
+class InvalidAttributeTypeError(ValidationError):
+    def __init__(self, ref: str, attr: str, file: str):
+        super().__init__(f"Invalid type {ref} for {attr} in {file}")

--- a/ocsf_validator/runner.py
+++ b/ocsf_validator/runner.py
@@ -20,7 +20,8 @@ from ocsf_validator.validators import (validate_include_targets,
                                        validate_no_unknown_keys,
                                        validate_required_keys,
                                        validate_undefined_attrs,
-                                       validate_unused_attrs)
+                                       validate_unused_attrs,
+                                       validate_attr_types)
 
 
 class Severity(IntEnum):
@@ -94,6 +95,9 @@ class ValidatorOptions:
     invalid_metaschema_file: int = Severity.ERROR
     """A JSON schema metaschema file is missing or invalid."""
 
+    invalid_attr_types: int = Severity.ERROR
+    """Attribute type is invalid."""
+
     def severity(self, err: Exception):
         match type(err):
             case errors.MissingRequiredKeyError:
@@ -128,6 +132,8 @@ class ValidatorOptions:
                 return self.undefined_attribute
             case errors.InvalidMetaSchemaFileError:
                 return self.invalid_metaschema_file
+            case errors.InvalidAttributeTypeError:
+                return self.invalid_attr_types
             case _:
                 return Severity.INFO
 
@@ -278,6 +284,13 @@ class ValidationRunner:
             test(
                 "Names are not used multiple times within a record type",
                 lambda: validate_intra_type_collisions(
+                    reader, collector=collector, types=types
+                ),
+            )
+
+            test(
+                "Attribute type references are defined",
+                lambda: validate_attr_types(
                     reader, collector=collector, types=types
                 ),
             )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -146,6 +146,39 @@ def test_validate_intra_type_collisions():
     # no error
     validate_intra_type_collisions(r)
 
+def test_validate_attr_keys():
+    r = DictReader()
+    r.set_data(
+        {
+            "/objects/thing.json": {
+                "name": "thing",
+                "attributes": {
+                    "one": {"name": "one", "type": "string_t"},
+                    "two": {"name": "two", "type": "thing2"},
+                },
+            },
+            "/objects/thing2.json": {
+                "name": "thing2",
+                "attributes": {},
+            },
+            "/objects/dictionary.json": {
+                "types": {
+                    "attributes": {
+                        "string_t": {},
+                    },
+                },
+            },
+        }
+    )
+
+    # raise no errors
+    validate_attr_types(r)
+
+    r["/objects/thing2.json"]["name"] = "thing3"
+    with pytest.raises(InvalidAttributeTypeError) as exc:
+        validate_attr_types(r)
+
+
 
 def test_validate_metaschemas():
     # set up a json schema that expects an object with a name property only


### PR DESCRIPTION
This PR adds a validation to ensure that attribute type references are valid.

If an attribute type ends with `_t`, it is assumed to be scalar. Otherwise it is assumed to be an object.

If a scalar type is not found in the attribute dictionary's `types` section, validation will fail. The core dictionary and all extension dictionaries are searched.

If an object type references an object `name` that can't be found in the repository, validation will fail.