### PR TITLE
Additional metaschemas

### DIFF
--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -11,9 +11,13 @@ from ocsf_validator.errors import (Collector, InvalidMetaSchemaError,
                                    UndefinedAttributeError,
                                    UndetectableTypeError, UnknownKeyError,
                                    UnusedAttributeError, InvalidAttributeTypeError)
-from ocsf_validator.matchers import (AnyMatcher, DictionaryMatcher,
+from ocsf_validator.matchers import (AnyMatcher, 
+                                     CategoriesMatcher,
+                                     DictionaryMatcher,
                                      EventMatcher,
-                                     IncludeMatcher, ObjectMatcher,
+                                     ExtensionMatcher,
+                                     IncludeMatcher, 
+                                     ObjectMatcher,
                                      ProfileMatcher)
 
 from ocsf_validator.processor import process_includes
@@ -251,8 +255,13 @@ def validate_metaschemas(
     base_uri = "https://schemas.ocsf.io/"
     registry = get_registry(reader, base_uri)
     matchers = {
+        "event.schema.json": EventMatcher(),
+        "include.schema.json": IncludeMatcher(),
         "object.schema.json": ObjectMatcher(),
-        "event.schema.json": EventMatcher()
+        "profile.schema.json": ProfileMatcher(),
+        "categories.schema.json": CategoriesMatcher(),
+        "dictionary.schema.json": DictionaryMatcher(),
+        "extension.schema.json": ExtensionMatcher(),
     }
 
     for metaschema, matcher in matchers.items():

--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -283,7 +283,8 @@ def validate_metaschemas(
             for error in errors:
                 collector.handle(
                     InvalidMetaSchemaError(
-                        f"File at {file} does not pass metaschema validation. Error: {error.message}"
+                        f"File at {file} does not pass metaschema validation. "
+                        f"Error: {error.message} at JSON path: '{error.json_path}'"
                     )
                 )
 

--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -2,6 +2,7 @@ import jsonschema
 import json
 import referencing
 import referencing.exceptions
+from pathlib import Path
 from typing import Callable, Dict, Optional
 
 from ocsf_validator.errors import (Collector, InvalidMetaSchemaError,
@@ -248,7 +249,7 @@ def validate_metaschemas(
     collector: Collector = Collector.default,
     types: Optional[TypeMapping] = None,
     get_registry: Callable[[Reader, str], referencing.Registry] = _default_get_registry
-):
+) -> None:
     if types is None:
         types = TypeMapping(reader)
 
@@ -275,9 +276,9 @@ def validate_metaschemas(
             )
             continue
             
-        def validate(reader: Reader, file: str):
-            data = reader[file]
-
+        def validate(reader: Reader, file: str) -> None:
+            with open(Path(reader.base_path, file), "r") as f:
+                data = json.load(f)
             validator = jsonschema.Draft202012Validator(schema, registry=registry)
             errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
             for error in errors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ocsf-validator"
 version = "0.1.3"
 description = "OCSF Schema Validation"
-authors = ["Jeremy Fisher <jeremy@query.ai>"]
+authors = ["Jeremy Fisher <jeremy@query.ai>", "Alan Pinkert <apinkert@cisco.com>"]
 readme = "README.md"
 packages = [{include = "ocsf_validator"}]
 


### PR DESCRIPTION
This pull request:

* Adds metaschema validation for the additional metaschemas that are now a part of the `ocsf-schema` repository.
* Adds my name to project authors, as requested 😄 
* Improves the error handling for when schemas fail

Here's an example of the new error message.  Before, it was missing the JSON path, so it wasn't always obvious where in the document the error was.

```sh
TESTING: JSON files match their metaschema definitions
   FATAL: File at objects/group.json does not pass metaschema validation. Error: 'foo' is not one of ['optional', 'recommended', 'required'] at JSON path: '$.attributes.domain.requirement'
```